### PR TITLE
Promote Springbok-LLC main to upstream

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!--
+Closes / Fixes / Resolves is what auto-closes the issue on merge, which is what
+moves the board card to Done. A bare "#4" or "tracked in #4" is only a mention —
+it links nothing and moves nothing. One keyword per issue: "Closes #4, closes #5".
+Delete the line if this PR genuinely closes nothing.
+-->
+Closes #
+
+## What & why
+
+<!-- What changed, and the reason. Keep it to what a reviewer needs. -->
+
+## Notes for review
+
+<!-- Anything non-obvious: a tradeoff taken, a thing deliberately left out, a risk. -->

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,9 +27,7 @@ jobs:
         run: make
 
       - name: Build package
-        run: |
-          pip install build hatch-vcs
-          python -m build
+        run: uv build
 
       - name: Attach to release
         run: gh release upload "${{ github.ref_name }}" dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,18 @@ source = "vcs"
 [tool.hatch.publish.index.repos.github-publish]
 url = "https://upload.pkg.github.com/orgs/NIH-NLM/packages/pypi/ckn-schema/"
 
+[tool.hatch.build.targets.sdist]
+artifacts = [
+  "src/ckn_schema/pydantic/ckn_schema.py",
+  "src/ckn_schema/schema/ckn_schema.yaml",
+  "src/ckn_schema/shacl/ckn_schema.shacl.ttl",
+  "src/ckn_schema/jsonschema/ckn_schema.json",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/ckn_schema"]
 artifacts = [
+  "src/ckn_schema/pydantic/ckn_schema.py",
   "src/ckn_schema/schema/ckn_schema.yaml",
   "src/ckn_schema/shacl/ckn_schema.shacl.ttl",
   "src/ckn_schema/jsonschema/ckn_schema.json",

--- a/uv.lock
+++ b/uv.lock
@@ -289,14 +289,19 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "linkml", version = "1.9.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "linkml", version = "1.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "rdflib" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "jsonschema", marker = "extra == 'dev'" },
     { name = "linkml", marker = "extra == 'dev'", specifier = ">=1.8,<2" },
     { name = "linkml-runtime", specifier = ">=1.9,<2" },
+    { name = "rdflib", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
Automated promotion from Springbok-LLC fork (2 commit(s) ahead, 0 behind).

Awaits manual review/merge upstream; this workflow does not merge.

Workflow run: https://github.com/Springbok-LLC/nlm-ckn-schema/actions/runs/26110097912